### PR TITLE
Fixed bug in perturb_k_list

### DIFF
--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -1270,8 +1270,8 @@ int perturb_get_k_list(
 
     /* allocate array with, for the moment, the largest possible size */
     class_alloc(ppt->k[ppt->index_md_scalars],
-                ((int)((k_max_cmb-k_min)/k_rec/MIN(ppr->k_step_super,ppr->k_step_sub))+
-                 (int)(MAX(ppr->k_per_decade_for_pk,ppr->k_per_decade_for_bao)*log(k_max/k_min)/log(10.))+1)
+                ((ceil)((k_max_cmb-k_min)/k_rec/MIN(ppr->k_step_super,ppr->k_step_sub))+
+                 (ceil)(MAX(ppr->k_per_decade_for_pk,ppr->k_per_decade_for_bao)*log(k_max/k_min)/log(10.))+1)
                 *sizeof(double),ppt->error_message);
 
     /* first value */

--- a/test_bug.ini
+++ b/test_bug.ini
@@ -1,0 +1,30 @@
+*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
+*  CLASS input parameter file  *
+*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
+
+output = mPk
+
+P_k_max_h/Mpc = 10
+k_per_decade_for_pk = 10
+k_per_decade_for_bao = 10
+
+H0 = 72.
+omega_b = 0.0266691
+omega_cdm = 0.110616
+
+reio_parametrization = reio_camb
+z_reio = 10.
+
+A_s_ad = 2.3e-9
+n_s_ad = 1.
+l_scalar_max = 2500
+
+background_verbose = 0
+thermodynamics_verbose = 0
+perturbations_verbose = 1
+transfer_verbose = 1
+primordial_verbose = 1
+spectra_verbose = 1
+nonlinear_verbose = 0
+lensing_verbose = 0
+output_verbose = 0


### PR DESCRIPTION
The bug led to segmentation faults when 'k_per_decade_for_pk'
and 'k_per_decade_for_bao' are set to the same value. Try
'./class test_bug.ini' with the previous version of CLASS to reproduce
the bug. If it does not show up, use Valgrind.
