### PR TITLE
Fix for halofit inaccuracies

### DIFF
--- a/include/arrays.h
+++ b/include/arrays.h
@@ -171,6 +171,17 @@ extern "C" {
 				 ErrorMsg errmsg
 				 );
 
+  int array_integrate_all_spline_nint(
+				 double * array,
+				 int n_columns,
+				 int n_lines,
+				 int n_int,
+				 int index_x,   /** from 0 to (n_columns-1) */
+				 int index_y,
+				 int index_ddy,
+				 double * result,
+				 ErrorMsg errmsg);
+
 int array_integrate_all_trapzd_or_spline(
 		   double * array,
 		   int n_columns,
@@ -240,6 +251,18 @@ int array_integrate_all_trapzd_or_spline(
 			       int * __restrict__ last_index,
 			       double * __restrict__ result,
 			       int result_size, /** from 1 to n_columns */
+			       ErrorMsg errmsg);
+
+  int array_interpolate_all_spline(
+			       double * array,
+			       int n_columns,
+			       int n_lines,
+			       int index_x,
+			       int index_y,
+			       int index_ddy,
+			       double x,
+			       int * last_index,
+			       double * result,
 			       ErrorMsg errmsg);
 
   int array_interpolate_linear(

--- a/source/nonlinear.c
+++ b/source/nonlinear.c
@@ -119,8 +119,6 @@ int nonlinear_init(
 
       //class_stop(pnl->error_message,"stop here");
 
-      //printf("dz = %lf  ",ppr->halofit_dz);
-
       /* get P_NL(k) at this time */
       if (nonlinear_halofit(ppr,
                             pba,
@@ -375,8 +373,7 @@ int nonlinear_halofit(
                     ppr->halofit_min_k_nonlinear);
 
   xlogr2 = log(R)/log(10.);
-  //xlogr1=-2.;
-  //xlogr2=3.5;
+
   counter = 0;
   do {
     rmid = pow(10,(xlogr2+xlogr1)/2.0);

--- a/source/nonlinear.c
+++ b/source/nonlinear.c
@@ -118,7 +118,7 @@ int nonlinear_init(
       */
 
       //class_stop(pnl->error_message,"stop here");
-      
+
       //printf("dz = %lf  ",ppr->halofit_dz);
 
       /* get P_NL(k) at this time */
@@ -339,7 +339,7 @@ int nonlinear_halofit(
              pnl->error_message,
              pnl->error_message);
   sigma  = sqrt(sum1);
-  
+
   class_test_except(sigma < 1.,
                     pnl->error_message,
                     free(pvecback);free(integrand_array),
@@ -360,7 +360,6 @@ int nonlinear_halofit(
   }
   /* fill in second derivatives */
   class_call(array_spline(integrand_array,7,pnl->k_size,0,1,2,_SPLINE_EST_DERIV_,pnl->error_message),
-  //class_call(array_spline(integrand_array,7,pnl->k_size,0,1,2,_SPLINE_NATURAL_,pnl->error_message),
              pnl->error_message,
              pnl->error_message);
   /* integrate */
@@ -395,7 +394,7 @@ int nonlinear_halofit(
       integrand_array[index_k*7 + 5] = pk_l[index_k]*pow(pnl->k[index_k],2)*anorm*4.*x2*(1.-x2)*exp(-x2);
     }
     /* fill in second derivatives */
-    class_call(array_spline(integrand_array,7,pnl->k_size,0,1,2,_SPLINE_NATURAL_,pnl->error_message),
+    class_call(array_spline(integrand_array,7,pnl->k_size,0,1,2,_SPLINE_EST_DERIV_,pnl->error_message),
                pnl->error_message,
                pnl->error_message);
     class_call(array_spline(integrand_array,7,pnl->k_size,0,3,4,_SPLINE_EST_DERIV_,pnl->error_message),
@@ -406,7 +405,7 @@ int nonlinear_halofit(
                pnl->error_message);
 
     /* integrate */
-    
+
     class_call(array_integrate_all_spline_nint(integrand_array,7,pnl->k_size,3e+3,0,1,2,&sum1,pnl->error_message),
                pnl->error_message,
                pnl->error_message);
@@ -445,9 +444,6 @@ int nonlinear_halofit(
   rncur = -d2;
 
   *k_nl = rknl;
-
-  //printf("Number of ks = %i\n",pnl->k_size);
-  //printf("%lf     %lf     %lf     %lf\n",pba->a_today/pvecback[pba->index_bg_a]-1.,rknl,rneff,rncur);
 
   for (index_k = 0; index_k < pnl->k_size; index_k++){
 
@@ -494,7 +490,7 @@ int nonlinear_halofit(
         f3=1.;
       }
 
-      y=(rk/rknl); 
+      y=(rk/rknl);
       pk_halo = a*pow(y,f1*3.)/(1.+b*pow(y,f2)+pow(f3*c*y,3.-gam));
       pk_halo=pk_halo/(1+xmu*pow(y,-1)+xnu*pow(y,-2))*(1+fnu*(0.977-18.015*(Omega0_m-0.3)));
       pk_linaa=pk_lin*(1+fnu*47.48*pow(rk,2)/(1+1.5*pow(rk,2)));

--- a/tools/arrays.c
+++ b/tools/arrays.c
@@ -1491,9 +1491,7 @@ int array_integrate_all_spline_nint(
 
   for (i=1; i <= n_int; i++) {
     kh = exp(log(array[index_x])+i*dkh);
-    //kh = (array[index_x])+i*dkh;
     array_interpolate_all_spline(array,n_columns,n_lines,index_x,index_y,index_ddy,kh,&index_previous,&integrand,errmsg);
-    //fprintf(f2,"%e\t%e\n",kh,integrand);
     integrand *= kh;
     *result += 0.5*(integrand_previous+integrand)*dkh;
     integrand_previous = integrand;

--- a/tools/arrays.c
+++ b/tools/arrays.c
@@ -1488,10 +1488,6 @@ int array_integrate_all_spline_nint(
   *result = 0.;
 
   dkh = (log(array[(n_lines-1)*n_columns+index_x])-log(array[index_x]))/n_int;
-  //dkh = ((array[(n_lines-1)*n_columns+index_x])-(array[index_x]))/n_int;
-  //printf("kmax = %lf\nkmin = %lf\ndkh = %lf\n", array[(n_lines-1)*n_columns+index_x], array[index_x], dkh );
-
-  //FILE *f2 = fopen("/home/matteo/prove_nonlin/output.txt","a");
 
   for (i=1; i <= n_int; i++) {
     kh = exp(log(array[index_x])+i*dkh);
@@ -1502,12 +1498,6 @@ int array_integrate_all_spline_nint(
     *result += 0.5*(integrand_previous+integrand)*dkh;
     integrand_previous = integrand;
   }
-
-  //fclose(f2);
-
-  // FILE *f1 = fopen("/home/matteo/prove_nonlin/input.txt","a");
-  // for(i=0; i<n_lines; i++) fprintf(f1,"%e\t%e\n",array[i*n_columns+index_x],array[i*n_columns+index_y]);
-  // fclose(f1);
 
   return _SUCCESS_;
 }
@@ -1814,15 +1804,6 @@ int array_interpolate_all_spline(
   inf=0;
   sup=n_lines-1;
 
-  // if (x>array[*last_index*n_columns+index_x] ) inf = *last_index;
-
-  // if ( x > array[*last_index*n_columns+index_x]  && x < array[(*last_index+1)*n_columns+index_x] )
-  // {
-  //   sup = inf+1;
-  // }
-  // else
-  // {
-
   if (array[inf*n_columns+index_x] < array[sup*n_columns+index_x]){
 
     if (x < array[inf*n_columns+index_x]) {
@@ -1866,7 +1847,6 @@ int array_interpolate_all_spline(
     }
 
   }
-  //}
 
   *last_index = inf;
 
@@ -1874,16 +1854,11 @@ int array_interpolate_all_spline(
   b = (x-array[inf*n_columns+index_x])/h;
   a = 1-b;
 
-  /*for (i=0; i<result_size; i++)*/
     *result =
       a * array[inf*n_columns+index_y] +
       b * array[sup*n_columns+index_y] +
       ((a*a*a-a)* array[inf*n_columns+index_ddy] +
        (b*b*b-b)* array[sup*n_columns+index_ddy])*h*h/6.;
-
-  // FILE *f3 = fopen("/home/matteo/prove_nonlin/supinf_spline.txt","a");
-  // fprintf(f3,"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\n",h,a,b,array[inf*n_columns+index_y],array[sup*n_columns+index_y],array[inf*n_columns+index_ddy],array[sup*n_columns+index_ddy],*result);
-  // fclose(f3);
 
   return _SUCCESS_;
 }


### PR DESCRIPTION
2 fixes for the computation of the non-linear matter power spectrum:

1) In file nonlinear.c, in the computation of alpha, I've changed abs() to fabs() to avoid casting a floating point number to integer.

2) In nonlinear.c the integration for computing sigma, d1 and d2 (used for obtaining k_nl, rneff and rncur) was performed on a small table of wavenumbers, resulting in imprecise values of the halofit parameters. I've forced the integration to be performed on a finer grid introducing 2 new functions in tools/arrays.c, namely integrate_all_spline_nint(), that can be called specifying the number of points on the integration grid, and interpolate_all_spline() that does the interpolation. The include/arrays.h file has been changed accordingly.

Attached, a plot of the comparison between the non-linear power spectra computed using class and camb, before and after this fix.
[halofit_in_class.pdf](https://github.com/lesgourg/class_public/files/112065/halofit_in_class.pdf)
