### PR TITLE
Update nonlinear.c

### DIFF
--- a/source/nonlinear.c
+++ b/source/nonlinear.c
@@ -465,7 +465,7 @@ int nonlinear_halofit(
       c=pow(10, 0.3698+2.0404*rneff+0.8161*rneff*rneff+0.5869*rncur);
       xmu=0.;
       xnu=pow(10,5.2105+3.6902*rneff);
-      alpha=abs(6.0835+1.3373*rneff-0.1959*rneff*rneff-5.5274*rncur);
+      alpha=fabs(6.0835+1.3373*rneff-0.1959*rneff*rneff-5.5274*rncur);
       beta=2.0379-0.7354*rneff+0.3157*pow(rneff,2)+1.2490*pow(rneff,3)+0.3980*pow(rneff,4)-0.1682*rncur + fnu*(1.081 + 0.395*pow(rneff,2));
 
       if(fabs(1-Omega_m)>0.01) { /*then omega evolution */


### PR DESCRIPTION
The function abs() casts the variable alpha into an integer. The function fabs() should be used instead. At least with my compiler, this change leads to visible differences in the resulting matter power spectrum.
