### PR TITLE
added reio_bins_linear option

### DIFF
--- a/explanatory.ini
+++ b/explanatory.ini
@@ -205,16 +205,21 @@ YHe = BBN
 
 recombination = RECFAST
 
-2) parametrization of reionization: 'reio_parametrization' must be one
-   of 'reio_none' (no reionization), 'reio_camb' (like CAMB: one
-   tanh() step for hydrogen reionization one for second helium
-   reionization), 'reio_bins_tanh' (binned history x_e(z) with tanh()
-   interpolation between input values), 'reio_half_tanh' (like
-   'reio_camb' excepted that we match the function xe(z) from
-   recombination with only half a tanh(z-z_reio)), 'reio_many_tanh'
-   (arbitrary number of tanh-like steps with specified central values,
-   a scheme usually more useful than 'reio_bins_tanh')...  (default:
-   set to 'reio_camb')
+2) parametrization of reionization: 'reio_parametrization' must be one of
+  * 'reio_none' - no reionization
+  * 'reio_camb' - like CAMB: one tanh() step for hydrogen reionization one for
+    second helium reionization
+  * 'reio_bins_tanh' - binned history x_e(z) with tanh() interpolation between
+    input values
+  * 'reio_bins_linear' - binned history x_e(z) with linear interpolation
+    between input values
+  * 'reio_half_tanh' - like 'reio_camb' excepted that we match the function
+    xe(z) from recombination with only half a tanh(z-z_reio),
+  * 'reio_many_tanh' - arbitrary number of tanh-like steps with specified
+    central values, a scheme usually more useful than 'reio_bins_tanh'...
+
+  (default: set to 'reio_camb')
+
 
 reio_parametrization = reio_camb
 
@@ -232,9 +237,9 @@ reionization_width = 0.5
 helium_fullreio_redshift = 3.5
 helium_fullreio_width = 0.5
 
-3.b.) if 'reio_parametrization' set to 'reio_bins_tanh': enter number of bins
+3.b.) if 'reio_parametrization' set to 'reio_bins_tanh' or 'reio_bins_linear': enter number of bins
       and list of z_i and xe_i defining the free electron density at the center
-      of each bin. Also enter a dimensionless paramater regulating the
+      of each bin. For 'reio_bins_tanh', also enter a dimensionless paramater regulating the
       sharpness of the tanh() steps, independently of the bin width;
       recommended sharpness is 0.3, smaller values will make steps too sharp,
       larger values will make the step very progressive but with discontinuity

--- a/include/thermodynamics.h
+++ b/include/thermodynamics.h
@@ -24,9 +24,10 @@ enum recombination_algorithm {
 enum reionization_parametrization {
   reio_none, /**< no reionization */
   reio_camb,  /**< reionization parameterized like in CAMB */
-  reio_bins_tanh,  /**< binned reionization history with tanh inteprolation between bins */
-  reio_half_tanh,  /**< half a tanh, instead of the full tanh */
-  reio_many_tanh   /**< similar to reio_camb but with more than one tanh */
+  reio_bins_linear, /**< binned reionization history with linear inteprolation between bins */  
+  reio_bins_tanh,   /**< binned reionization history with tanh inteprolation between bins */
+  reio_half_tanh,   /**< half a tanh, instead of the full tanh */
+  reio_many_tanh    /**< similar to reio_camb but with more than one tanh */
 };
 
 /**

--- a/source/input.c
+++ b/source/input.c
@@ -1082,6 +1082,10 @@ int input_read_parameters(
       pth->reio_parametrization=reio_camb;
       flag2=_TRUE_;
     }
+    if (strcmp(string1,"reio_bins_linear") == 0) {
+      pth->reio_parametrization=reio_bins_linear;
+      flag2=_TRUE_;
+    }
     if (strcmp(string1,"reio_bins_tanh") == 0) {
       pth->reio_parametrization=reio_bins_tanh;
       flag2=_TRUE_;
@@ -1097,7 +1101,7 @@ int input_read_parameters(
 
     class_test(flag2==_FALSE_,
                errmsg,
-               "could not identify reionization_parametrization value, check that it is one of 'reio_none', 'reio_camb', 'reio_bins_tanh', 'reio_half_tanh', 'reio_many_tanh'...");
+               "could not identify reionization_parametrization value, check that it is one of 'reio_none', 'reio_camb', 'reio_bins_tanh', 'reio_bins_linear', 'reio_half_tanh', 'reio_many_tanh'...");
   }
 
   /** - reionization parameters if reio_parametrization=reio_camb */
@@ -1133,6 +1137,13 @@ int input_read_parameters(
     class_read_list_of_doubles("binned_reio_z",pth->binned_reio_z,pth->binned_reio_num);
     class_read_list_of_doubles("binned_reio_xe",pth->binned_reio_xe,pth->binned_reio_num);
     class_read_double("binned_reio_step_sharpness",pth->binned_reio_step_sharpness);
+  }
+
+  /** - reionization parameters if reio_parametrization=reio_bins_linear */
+  if (pth->reio_parametrization == reio_bins_linear) {
+    class_read_int("binned_reio_num",pth->binned_reio_num);
+    class_read_list_of_doubles("binned_reio_z",pth->binned_reio_z,pth->binned_reio_num);
+    class_read_list_of_doubles("binned_reio_xe",pth->binned_reio_xe,pth->binned_reio_num);
   }
 
   /** - reionization parameters if reio_parametrization=reio_many_tanh */


### PR DESCRIPTION
Added the option `reio_bins_linear` to `reio_parametrization` which works similarly to `reio_bins_tanh` but just does linear interpolation instead so that you can by hand put in exactly whatever reionization history you want. 