### PR TITLE
Compatibility for Python 2 and 3

### DIFF
--- a/CPU.py
+++ b/CPU.py
@@ -31,6 +31,8 @@ https://github.com/JesusTorrado/cosmo_mini_toolbox
 
 """
 
+from __future__ import unicode_literals, print_function
+
 # System imports
 import os
 import sys

--- a/CPU.py
+++ b/CPU.py
@@ -30,7 +30,7 @@ cosmo_mini_toolbox, available under GPLv3 at
 https://github.com/JesusTorrado/cosmo_mini_toolbox
 
 """
-from __future__ import unicode_literals
+
 # System imports
 import os
 import sys
@@ -343,8 +343,8 @@ def plot_CLASS_output(files, x_axis, y_axis, ratio=False, printing='',
     # Write to the python file all the issued commands. You can then reproduce
     # the plot by running "python output/something_cl.dat.py"
     with open(python_script_path, 'w') as python_script:
-        print 'Creating a python script to reproduce the figure'
-        print '--> stored in %s' % python_script_path
+        print('Creating a python script to reproduce the figure')
+        print('--> stored in %s' % python_script_path)
         python_script.write('\n'.join(text))
 
     # If the use wants to print the figure to a file
@@ -439,7 +439,7 @@ def extract_headers(header_path):
 
 
 def main():
-    print '~~~ Running CPU, a CLASS Plotting Utility ~~~'
+    print('~~~ Running CPU, a CLASS Plotting Utility ~~~')
     parser = CPU_parser()
     # Parse the command line arguments
     args = parser.parse_args()
@@ -480,7 +480,7 @@ def main():
     # performed. If asked to be divided, the ratio is shown - whether a need
     # for interpolation arises or not.
     if args.ratio and args.scale == 'loglog':
-        print "Defaulting to loglin scale"
+        print("Defaulting to loglin scale")
         args.scale = 'loglin'
 
     plot_CLASS_output(args.files, args.x_axis, args.y_axis,

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CC       = gcc
 AR        = ar rv
 
 # (OPT) your python interpreter
-PYTHON = python
+PYTHON ?= python
 
 # your optimization flag
 OPTFLAG = -O4 -ffast-math #-march=native
@@ -60,7 +60,7 @@ EXTERNAL =
 
 # Try to automatically avoid an error 'error: can't combine user with ...'
 # which sometimes happens with brewed Python on OSX:
-CFGFILE=$(shell $(PYTHON) -c "import sys; print sys.prefix+'/lib/'+'python'+'.'.join(['%i' % e for e in sys.version_info[0:2]])+'/distutils/distutils.cfg'")
+CFGFILE=$(shell $(PYTHON) -c "from __future__ import print_function; import sys; print(sys.prefix+'/lib/'+'python'+'.'.join(['%i' % e for e in sys.version_info[0:2]])+'/distutils/distutils.cfg')")
 PYTHONPREFIX=$(shell grep -s "prefix" $(CFGFILE))
 ifeq ($(PYTHONPREFIX),)
 PYTHONFLAGS=--user

--- a/external_Pk/generate_Pk_example.py
+++ b/external_Pk/generate_Pk_example.py
@@ -51,5 +51,5 @@ while ks[-1] <= float(k_max) :
 # Filling the array of Pk's
 for k in ks :
     P_k = P(k)
-    print "%.18g %.18g" % (k, P_k)
+    print("%.18g %.18g" % (k, P_k))
 

--- a/external_Pk/generate_Pk_example.py
+++ b/external_Pk/generate_Pk_example.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys
 from math import exp
 

--- a/external_Pk/generate_Pk_example_w_tensors.py
+++ b/external_Pk/generate_Pk_example_w_tensors.py
@@ -55,5 +55,5 @@ while ks[-1] <= float(k_max) :
 
 # Filling the array of Pk's
 for k in ks :
-    print "%.18g %.18g %.18g" % (k, P_s(k), P_t(k))
+    print("%.18g %.18g %.18g" % (k, P_s(k), P_t(k)))
 

--- a/external_Pk/generate_Pk_example_w_tensors.py
+++ b/external_Pk/generate_Pk_example_w_tensors.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys
 from math import exp
 

--- a/python/classy.pyx
+++ b/python/classy.pyx
@@ -33,7 +33,7 @@ DEF _MAXTITLESTRINGLENGTH_ = 8000
 # MontePython to handle things differently.
 class CosmoError(Exception):
     def __init__(self, message=""):
-        self.message = message
+        self.message = message.decode() if isinstance(message,bytes) else message
 
     def __str__(self):
         return '\n\nError in Class: ' + self.message
@@ -158,9 +158,10 @@ cdef class Class:
         i = 0
         for kk in self._pars:
 
-            dumc = kk
+            dumcp = kk.encode()
+            dumc = dumcp
             sprintf(self.fc.name[i],"%s",dumc)
-            dumcp = str(self._pars[kk])
+            dumcp = str(self._pars[kk]).encode()
             dumc = dumcp
             sprintf(self.fc.value[i],"%s",dumc)
             self.fc.read[i] = _FALSE_
@@ -311,7 +312,7 @@ cdef class Class:
             for i in range(self.fc.size):
                 if self.fc.read[i] == _FALSE_:
                     problem_flag = True
-                    problematic_parameters.append(self.fc.name[i])
+                    problematic_parameters.append(self.fc.name[i].decode())
             if problem_flag:
                 raise CosmoSevereError(
                     "Class did not read input parameter(s): %s\n" % ', '.join(

--- a/python/extract_errors.py
+++ b/python/extract_errors.py
@@ -29,9 +29,9 @@ def main(path):
                             if text[i].startswith('E'):
                                 contains_error = True
                     if contains_error:
-                        print 'Found an error'
+                        print('Found an error')
                         for i in range(start, stop+1):
-                            print text[i],
+                            print(text[i], end=' ')
                             destination.write(text[i])
                     start = index
                     contains_error = False
@@ -43,7 +43,7 @@ def main(path):
 
 
 if __name__ == "__main__":
-    print sys.argv
+    print(sys.argv)
     if len(sys.argv) != 2:
         print('Please specify the output file to analyse')
         exit()

--- a/python/extract_errors.py
+++ b/python/extract_errors.py
@@ -1,7 +1,7 @@
 # From the dumped stdout and stderr of a nosetests test_class.py, extract all
 # the failed steps.
 # Usage: python extract_errors.py output
-
+from __future__ import print_function
 import sys
 import os
 

--- a/python/interface_generator.py
+++ b/python/interface_generator.py
@@ -1,7 +1,7 @@
 """
 Automatically reads header files to generate an interface
 """
-from __future__ import division, print_function
+
 import sys
 import logging
 try:
@@ -88,7 +88,7 @@ def main():
     for header in headers:
         extract_headers(header, structs, output_file, logger)
     logger.info("Finished extracting headers")
-    for struct_name, struct in structs.iteritems():
+    for struct_name, struct in list(structs.items()):
         create_wrapper_class(struct_name, struct, output_file, logger)
 
     return
@@ -315,7 +315,7 @@ def create_wrapper_class(struct_name, struct, of, logger):
     # Define the array variables for all needed
     array_variables = []
     variables = []
-    for key, value in struct.iteritems():
+    for key, value in list(struct.items()):
         if key != 'init':
             if value[1]:
                 array_variables.append(key)

--- a/python/interface_generator.py
+++ b/python/interface_generator.py
@@ -1,7 +1,7 @@
 """
 Automatically reads header files to generate an interface
 """
-
+from __future__ import division, print_function
 import sys
 import logging
 try:
@@ -88,7 +88,7 @@ def main():
     for header in headers:
         extract_headers(header, structs, output_file, logger)
     logger.info("Finished extracting headers")
-    for struct_name, struct in list(structs.items()):
+    for struct_name, struct in structs.items():
         create_wrapper_class(struct_name, struct, output_file, logger)
 
     return
@@ -315,7 +315,7 @@ def create_wrapper_class(struct_name, struct, of, logger):
     # Define the array variables for all needed
     array_variables = []
     variables = []
-    for key, value in list(struct.items()):
+    for key, value in struct.items():
         if key != 'init':
             if value[1]:
                 array_variables.append(key)

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ import os.path as osp
 GCCPATH_STRING = sbp.Popen(
     ['gcc', '-print-libgcc-file-name'],
     stdout=sbp.PIPE).communicate()[0]
-GCCPATH = osp.normpath(osp.dirname(GCCPATH_STRING))
+GCCPATH = osp.normpath(osp.dirname(GCCPATH_STRING)).decode()
 
 # Recover the CLASS version
 with open(os.path.join('..', 'include', 'common.h'), 'r') as v_file:

--- a/python/test_class.py
+++ b/python/test_class.py
@@ -151,7 +151,7 @@ CLASS_INPUT['Lensing'] = (
 
 INPUTPOWER = []
 INPUTNORMAL = [{}]
-for key, value in CLASS_INPUT.iteritems():
+for key, value in list(CLASS_INPUT.items()):
     models, state = value
     if state == 'power':
         INPUTPOWER.append([{}]+models)
@@ -240,7 +240,7 @@ class TestClass(unittest.TestCase):
     def poormansname(self, somedict):
         string = "_".join(
             [k+'='+str(v)
-             for k, v in somedict.iteritems()])
+             for k, v in list(somedict.items())])
         string = string.replace('/', '%')
         string = string.replace(',', '')
         string = string.replace(' ', '')
@@ -256,13 +256,13 @@ class TestClass(unittest.TestCase):
         sys.stderr.write('\n\n---------------------------------\n')
         sys.stderr.write('| Test case %s |\n' % self.name)
         sys.stderr.write('---------------------------------\n')
-        for key, value in self.scenario.iteritems():
+        for key, value in list(self.scenario.items()):
             sys.stderr.write("%s = %s\n" % (key, value))
             sys.stdout.write("%s = %s\n" % (key, value))
         sys.stderr.write("\n")
 
         setting = self.cosmo.set(
-            dict(self.verbose.items()+self.scenario.items()))
+            dict(list(self.verbose.items())+list(self.scenario.items())))
         self.assertTrue(setting, "Class failed to initialize with input dict")
 
         cl_dict = {
@@ -291,13 +291,13 @@ class TestClass(unittest.TestCase):
             self.cosmo.state,
             "Class failed to go through all __init__ methods")
         if self.cosmo.state:
-            print '--> Class is ready'
+            print('--> Class is ready')
         # Depending
-        if 'output' in self.scenario.keys():
+        if 'output' in list(self.scenario.keys()):
             # Positive tests of raw cls
             output = self.scenario['output']
             for elem in output.split():
-                if elem in cl_dict.keys():
+                if elem in list(cl_dict.keys()):
                     for cl_type in cl_dict[elem]:
                         sys.stderr.write(
                             '--> testing raw_cl for %s\n' % cl_type)
@@ -313,7 +313,7 @@ class TestClass(unittest.TestCase):
                     pk = self.cosmo.pk(0.1, 0)
                     self.assertIsNotNone(pk, "pk returned nothing")
             # Negative tests of output functions
-            if not any([elem in cl_dict.keys() for elem in output.split()]):
+            if not any([elem in list(cl_dict.keys()) for elem in output.split()]):
                 sys.stderr.write('--> testing absence of any Cl\n')
                 self.assertRaises(CosmoSevereError, self.cosmo.raw_cl, 100)
             if 'mPk' not in output.split():
@@ -323,7 +323,7 @@ class TestClass(unittest.TestCase):
         if COMPARE_OUTPUT:
             # Now, compute with Newtonian gauge, and compare the results
             self.cosmo_newt.set(
-                dict(self.verbose.items()+self.scenario.items()))
+                dict(list(self.verbose.items())+list(self.scenario.items())))
             self.cosmo_newt.set({'gauge': 'newtonian'})
             self.cosmo_newt.compute()
             # Check that the computation worked
@@ -340,7 +340,7 @@ class TestClass(unittest.TestCase):
         # If we have tensor modes, we must have one tensor observable,
         # either tCl or pCl.
         if has_tensor(self.scenario):
-            if 'output' not in self.scenario.keys():
+            if 'output' not in list(self.scenario.keys()):
                 should_fail = True
             else:
                 output = self.scenario['output'].split()
@@ -349,8 +349,8 @@ class TestClass(unittest.TestCase):
 
         # If we have specified lensing, we must have lCl in output,
         # otherwise lensing will not be read (which is an error).
-        if 'lensing' in self.scenario.keys():
-            if 'output' not in self.scenario.keys():
+        if 'lensing' in list(self.scenario.keys()):
+            if 'output' not in list(self.scenario.keys()):
                 should_fail = True
             else:
                 output = self.scenario['output'].split()
@@ -360,33 +360,33 @@ class TestClass(unittest.TestCase):
                     should_fail = True
 
         # If we have specified a tensor method, we must have tensors.
-        if 'tensor method' in self.scenario.keys():
+        if 'tensor method' in list(self.scenario.keys()):
             if not has_tensor(self.scenario):
                 should_fail = True
 
         # If we have specified non linear, we must have some form of
         # perturbations output.
-        if 'non linear' in self.scenario.keys():
-            if 'output' not in self.scenario.keys():
+        if 'non linear' in list(self.scenario.keys()):
+            if 'output' not in list(self.scenario.keys()):
                 should_fail = True
 
         # If we ask for Cl's of lensing potential, we must have scalar modes.
-        if 'output' in self.scenario.keys() and 'lCl' in self.scenario['output'].split():
-            if 'modes' in self.scenario.keys() and self.scenario['modes'].find('s') == -1:
+        if 'output' in list(self.scenario.keys()) and 'lCl' in self.scenario['output'].split():
+            if 'modes' in list(self.scenario.keys()) and self.scenario['modes'].find('s') == -1:
                 should_fail = True
 
         # If we specify initial conditions (for scalar modes), we must have
         # perturbations and scalar modes.
-        if 'ic' in self.scenario.keys():
-            if 'modes' in self.scenario.keys() and self.scenario['modes'].find('s') == -1:
+        if 'ic' in list(self.scenario.keys()):
+            if 'modes' in list(self.scenario.keys()) and self.scenario['modes'].find('s') == -1:
                 should_fail = True
-            if 'output' not in self.scenario.keys():
+            if 'output' not in list(self.scenario.keys()):
                 should_fail = True
 
         # If we use inflation module, we must have scalar modes,
         # tensor modes, no vector modes and we should only have adiabatic IC:
-        if 'P_k_ini type' in self.scenario.keys() and self.scenario['P_k_ini type'].find('inflation') != -1:
-            if 'modes' not in self.scenario.keys():
+        if 'P_k_ini type' in list(self.scenario.keys()) and self.scenario['P_k_ini type'].find('inflation') != -1:
+            if 'modes' not in list(self.scenario.keys()):
                 should_fail = True
             else:
                 if self.scenario['modes'].find('s') == -1:
@@ -395,7 +395,7 @@ class TestClass(unittest.TestCase):
                     should_fail = True
                 if self.scenario['modes'].find('t') == -1:
                     should_fail = True
-            if 'ic' in self.scenario.keys() and self.scenario['ic'].find('i') != -1:
+            if 'ic' in list(self.scenario.keys()) and self.scenario['ic'].find('i') != -1:
                 should_fail = True
 
 
@@ -415,7 +415,7 @@ class TestClass(unittest.TestCase):
             except CosmoSevereError:
                 continue
             ref = getattr(reference, elem)()
-            for key, value in ref.iteritems():
+            for key, value in list(ref.items()):
                 if key != 'ell':
                     sys.stderr.write('--> testing equality of %s %s\n' % (
                         elem, key))
@@ -423,7 +423,7 @@ class TestClass(unittest.TestCase):
                     if key[0] == key[1]:
                         # If it is a 'dd' or 'll', it is a dictionary.
                         if isinstance(value, dict):
-                            for subkey in value.iterkeys():
+                            for subkey in list(value.keys()):
                                 try:
                                     np.testing.assert_allclose(
                                         value[subkey], to_test[key][subkey],
@@ -461,7 +461,7 @@ class TestClass(unittest.TestCase):
                             self.cl_faulty_plot(elem+"_"+key,
                                                 value[2:], to_test[key][2:])
 
-        if 'output' in self.scenario.keys():
+        if 'output' in list(self.scenario.keys()):
             if self.scenario['output'].find('mPk') != -1:
                 sys.stderr.write('--> testing equality of Pk')
                 k = np.logspace(
@@ -500,9 +500,9 @@ class TestClass(unittest.TestCase):
         fig.savefig(path+'_'+cl_type+'.pdf')
 
         # Store parameters (contained in self.scenario) to text file
-        parameters = dict(self.verbose.items()+self.scenario.items())
+        parameters = dict(list(self.verbose.items())+list(self.scenario.items()))
         with open(path+'.ini', 'w') as param_file:
-            for key, value in parameters.iteritems():
+            for key, value in list(parameters.items()):
                 param_file.write(key+" = "+str(value)+'\n')
 
     def pk_faulty_plot(self, k, reference, candidate):
@@ -528,14 +528,14 @@ class TestClass(unittest.TestCase):
         fig.savefig(path+'_'+'pk'+'.pdf')
 
         # Store parameters (contained in self.scenario) to text file
-        parameters = dict(self.verbose.items()+self.scenario.items())
+        parameters = dict(list(self.verbose.items())+list(self.scenario.items()))
         with open(path+'.ini', 'w') as param_file:
-            for key, value in parameters.iteritems():
+            for key, value in list(parameters.items()):
                 param_file.write(key+" = "+str(value)+'\n')
 
 
 def has_tensor(input_dict):
-    if 'modes' in input_dict.keys():
+    if 'modes' in list(input_dict.keys()):
         if input_dict['modes'].find('t') != -1:
             return True
     else:

--- a/python/test_class.py
+++ b/python/test_class.py
@@ -68,6 +68,7 @@ rerun CLASS for each case under Newtonian gauge and then compare Cl's and
 matter power spectrum. If the two are not close enough, it will generate a
 PDF plot of this and save it in the 'fail' folder.
 """
+from __future__ import print_function
 from classy import Class
 from classy import CosmoSevereError
 import itertools


### PR DESCRIPTION
This makes CLASS work on both Python 2 and 3. 

The user can control which version to install by running either `PYTHON=python2 make all` or `PYTHON=python3 make all`. 

Basically I ran the 2to3 tool, fixed a few string encoding things by hand, and added `from __future__ import print_function` where needed so that the code will still work on 2.X. 

I've tested on Python 2.7.12 and 3.5.2. I'm seeing some unittest failures, but they all seem to be happening for me on the master branch too so I don't think its related to my modifications. 

It'd be nice to add some unittests ensuring Python 2/3 compatibility is kept with future changes, although I haven't done that here.
