### PR TITLE
Quintessence w(a) parametrization

### DIFF
--- a/include/background.h
+++ b/include/background.h
@@ -11,6 +11,7 @@
 #include "parser.h"
 
 enum spatial_curvature {flat,open,closed};
+enum {w_fld_parametrization_lin, w_fld_parametrization_tanh};
 
 /**
  * All background parameters and evolution that other modules need to know.
@@ -52,6 +53,9 @@ struct background
   double Omega0_fld; /**< \f$ \Omega_{0 de} \f$: fluid */
   double w0_fld; /**< \f$ w0_{DE} \f$: current fluid equation of state parameter */
   double wa_fld; /**< \f$ wa_{DE} \f$: fluid equation of state parameter derivative */
+  
+  short w_fld_parametrization; /**< flag switching between different parametrizations
+				\f$ w(a)\f$ - 0 is the normal linear parametrization */
 
   double cs2_fld; /**< \f$ c^2_{s~DE} \f$: sound speed of the fluid
 		     in the frame comoving with the fluid (so, this is

--- a/source/background.c
+++ b/source/background.c
@@ -506,6 +506,9 @@ int background_w_fld(
 
     double d0 = pba->w0_fld + 1.;
     double W0 = pba->Omega0_fld;
+    class_test(W0 < 0.0,
+	       pba->error_message,
+	       "Omega0_fld needs to be larger than zero for the tanh parametrization");
 
     *w_fld = -1. + (d0*pow(sqrt(1. + (-1. + 1./W0)/pow(scaleda,3)) - ((-1. + 1./W0)*atanh(1./sqrt(1. + (-1. + 1./W0)/pow(scaleda,3))))/pow(scaleda,3),2))/pow(1./sqrt(W0) - (-1. + 1./W0)*atanh(sqrt(W0)),2);
 

--- a/source/input.c
+++ b/source/input.c
@@ -1030,6 +1030,25 @@ int input_read_parameters(
       }
     }
 
+    class_call(parser_read_string(pfc,
+                                  "w_fld_parametrization",
+                                  &string1,
+                                  &flag1,
+                                  errmsg),
+                errmsg,
+                errmsg);
+    if (flag1 == _TRUE_){
+      if(strstr(string1,"tanh") != NULL){
+        pba->w_fld_parametrization = w_fld_parametrization_tanh;
+      }
+      else if(strstr(string1,"lin") != NULL){
+        pba->w_fld_parametrization = w_fld_parametrization_lin;
+      }
+      else {
+	class_stop(errmsg,"unknown parametrization '%s' for w(a), set w_fld_parametrization to either lin(default) or tanh",string1);
+      }
+    }
+
   }
 
   /* Additional SCF parameters: */
@@ -1103,6 +1122,9 @@ int input_read_parameters(
 
     if ((strstr(string1,"HYREC") != NULL) || (strstr(string1,"hyrec") != NULL) || (strstr(string1,"HyRec") != NULL)) {
       pth->recombination = hyrec;
+      class_test(pba->w_fld_parametrization != w_fld_parametrization_lin,
+               errmsg,
+               "HyRec assumes an equation of state parametrization w(a) = w0 + w1 (1-a) for the dark fluid.");
     }
 
   }
@@ -2896,6 +2918,7 @@ int input_default_params(
   pba->a_today = 1.;
   pba->w0_fld=-1.;
   pba->wa_fld=0.;
+  pba->w_fld_parametrization = w_fld_parametrization_lin;
   pba->cs2_fld=1.;
   pba->use_ppf = _TRUE_;
   pba->c_gamma_over_c_fld = 0.4;


### PR DESCRIPTION
Hi, 
This implements a different w(a) parametrization, suitable for thawing quintessence, namely eqn (26) from 0712.3450 - https://arxiv.org/abs/0712.3450. 
I thought it might be useful to merge this as it might be interesting for other people using quintessence and potentially it could act as a reference implementation for other w(a). 

I tried to stick close to the usual coding conventions for class. There is two places that especially need attention:
* background.c around line 513 - the formula given in the paper gets numerically instable in the limit a=0 - I thus implemented a cutoff that should only introduce tiny errors (I included the values as computed with mathematica at a=1e-3 in a comment), however I was not sure how to handle that in a better way.
* background.c around 1920 - I essentially adapted the Romberg integration algorithm found on wikipedia to our needs - currently the precision for the integration and the maximum number of recursions are still in background.c, I could pull them out and put them in a precision file. 

Please let me know if you are interested in merging this,
cheers, Martin