### PR TITLE
Increase max filename size

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -27,7 +27,7 @@
 #define _ERRORMSGSIZE_ 2048 /**< generic error messages are cut beyond this number of characters */
 typedef char ErrorMsg[_ERRORMSGSIZE_]; /**< Generic error messages (there is such a field in each structure) */
 
-#define _FILENAMESIZE_ 256 /**< size of the string read in each line of the file (extra characters not taken into account) */
+#define _FILENAMESIZE_ 512 /**< size of the string read in each line of the file (extra characters not taken into account) */
 typedef char FileName[_FILENAMESIZE_];
 
 #define _PI_ 3.1415926535897932384626433832795e0 /**< The number pi */


### PR DESCRIPTION
The default size 256 causes a overflow error on OSX with FORTIFY_SOURCE in our python binding, because to the conda-build path prefix generates file paths beyond this limit (it turned out to be 312 chars on my build bot).