### PR TITLE
Small steps toward making RSI py3 compatible

### DIFF
--- a/RealSpaceInterface/Calc2D/CalculationClass.py
+++ b/RealSpaceInterface/Calc2D/CalculationClass.py
@@ -98,7 +98,7 @@ class Calculation(object):
         return Value.ravel(), cv2.resize(
             (np.abs(self.FValue) - np.abs(self.FValue).min()) /
             (np.abs(self.FValue).max() - np.abs(self.FValue).min()),
-            (self.endshape[0] / 2, self.endshape[1])).ravel(), (minimum,
+            (self.endshape[0] // 2, self.endshape[1])).ravel(), (minimum,
                                                                 maximum)
 
     def getTransferData(self, redshiftindex):

--- a/RealSpaceInterface/Calc2D/Database.py
+++ b/RealSpaceInterface/Calc2D/Database.py
@@ -14,22 +14,22 @@ class Database:
         self.db_path = os.path.join(directory, db_file)
         if not os.path.exists(self.db_path):
             logging.info("No database found; Creating one at {}.".format(self.db_path))
-            with open(self.db_path, "w") as f:
+            with open(self.db_path, "wb") as f:
                 pickle.dump(dict(), f)
 
         self.db = self.__read_database()
 
     def __read_database(self):
-        with open(self.db_path) as f:
+        with open(self.db_path, "rb") as f:
             return pickle.load(f)
 
     def __write_database(self):
-        with open(self.db_path, "w") as f:
+        with open(self.db_path, "wb") as f:
             pickle.dump(self.db, f)
 
     def __create_file(self, data):
         filename = str(uuid.uuid4())
-        with open(os.path.join(self.directory, filename), "w") as f:
+        with open(os.path.join(self.directory, filename), "wb") as f:
             pickle.dump(data, f)
         return filename
 
@@ -40,7 +40,7 @@ class Database:
         frozen_key = self.__get_frozen_key(key)
         if frozen_key in self.db:
             filename = self.db[frozen_key]
-            with open(os.path.join(self.directory, filename)) as f:
+            with open(os.path.join(self.directory, filename, "rb")) as f:
                 return pickle.load(f)
         else:
             raise KeyError("No data for key: {}".format(key))


### PR DESCRIPTION
I have found that under python 3, writing to the RSI database breaks with a bytes vs. string issue when pickling, which is fixed if the pickle write/reading is binary (using `'wb'`/`'rb'`).  Also, the shape of the data has to be integers, which requires explicit integer division in py3.  There are a number of other things that would need to be fixed to make the app fully py3 compatible, as the JSON message writing breaks when trying to write bytes as well, but that seems more involved, so this is just a start to that.