### PR TITLE
Have 'make clean' delete python-installed classy binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,3 +195,4 @@ clean: .base
 	rm -f libclass.a
 	rm -f $(MDIR)/python/classy.c
 	rm -rf $(MDIR)/python/build
+	rm -f $(shell python -c "import classy; print(classy.__file__)")


### PR DESCRIPTION
I have been bit more than once by rebuilding class but still having an old version of the python-installed classy binary sitting around---I don't think it gets replaced just by running `make clean; make`.  This adds a line to the makefile to delete the currently active classy library upon `make clean`.