### PR TITLE
Fixed parsing of parameter "non linear"

### DIFF
--- a/source/input.c
+++ b/source/input.c
@@ -2505,10 +2505,8 @@ int input_read_parameters(
              errmsg);
 
   if (flag1 == _TRUE_) {
-
-    class_test(ppt->has_perturbations == _FALSE_, errmsg, "You requested non linear computation but no linear computation. You must set output to tCl or similar.");
-
     if ((strstr(string1,"halofit") != NULL) || (strstr(string1,"Halofit") != NULL) || (strstr(string1,"HALOFIT") != NULL)) {
+      class_test(ppt->has_perturbations == _FALSE_, errmsg, "You requested non linear computation but no linear computation. You must set output to tCl or similar.");
       pnl->method=nl_halofit;
       ppt->has_nl_corrections_based_on_delta_m = _TRUE_;
     }


### PR DESCRIPTION
Currently, if one sets the value of "non linear" to anything, and "output" is set to nothing, CLASS throws an error regarding nonlinearities. This is a bit strange, as in the Python wrapper the user can do something like `<instance>.set({'non linear' : ''})`, and CLASS will throw an error when calling `compute()`.
Instead, it should only throw an error if the value of "non linear" is explicitly set to something containing "halofit", "HALOFIT" or "Halofit" (as mentioned in the explanatory file), _and_ the user hasn't specified any output.