### PR TITLE
fix autosetup.py when OpenMP is turned off

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,8 @@ classy_ext = Extension("classy", [os.path.join(classy_folder, "classy.pyx")],
                            include_dirs=[nm.get_include(), include_folder],
                            libraries=liblist,
                            library_dirs=[root_folder, GCCPATH],
-                           extra_link_args=['-lgomp'])
+                           extra_link_args=['-lgomp']
+                           )
 import six
 classy_ext.cython_directives = {'language_level': "3" if six.PY3 else "2"}
         


### PR DESCRIPTION
The automatic installation of classy is handled in the Makefile as:
```make
ifdef OMPFLAG
	cp python/setup.py python/autosetup.py
else
	grep -v "lgomp" python/setup.py > python/autosetup.py
endif
	cd python; export CC=$(CC); $(PYTHON) autosetup.py install || $(PYTHON) autosetup.py install --user
	rm python/autosetup.py
```

If OpenMP is turned off, this deletes the line containing `lgomp`. However, that line contains a closing bracket which mustn't be deleted. In this PR I moved the closing bracket to a new line such that the line containing `lgomp` can be safely deleted.