### PR TITLE
Fix integer division in `density_cl`

### DIFF
--- a/python/classy.pyx
+++ b/python/classy.pyx
@@ -661,7 +661,7 @@ cdef class Class:
         # For density Cls, the size is bigger (different redshfit bins)
         # computes the size, given the number of correlations needed to be computed
         size = (self.sp.d_size*(self.sp.d_size+1)-(self.sp.d_size-self.sp.non_diag)*
-                (self.sp.d_size-1-self.sp.non_diag))/2;
+                (self.sp.d_size-1-self.sp.non_diag))//2;
         for elem in ['dd', 'll', 'dl']:
             if elem in spectra:
                 cl[elem] = {}


### PR DESCRIPTION
Fix for #339 
`density_cl` was returning a `TypeError` due to the fact that Python 3's division operator `/`
is always assuming its doing float division, replaced it with `//`, the integer division operator, which works in both Python 2 and 3.