### PR TITLE
Python3 fixes for RealSpaceInterface

### DIFF
--- a/RealSpaceInterface/Calc2D/CalculationClass.py
+++ b/RealSpaceInterface/Calc2D/CalculationClass.py
@@ -71,7 +71,7 @@ class Calculation(object):
         Valuenew = dict()
         FValue_abs = np.abs(self.FValue)
         _min, _max = FValue_abs.min(), FValue_abs.max()
-        dimensions = (self.endshape[0] / 2, self.endshape[1])
+        dimensions = (self.endshape[0] // 2, self.endshape[1])
         for quantity, FT in FValuenew.items():
             FT_abs = np.abs(FT)
             FT_normalized = cv2.resize(FT_abs, dimensions).ravel()
@@ -98,7 +98,7 @@ class Calculation(object):
         return Value.ravel(), cv2.resize(
             (np.abs(self.FValue) - np.abs(self.FValue).min()) /
             (np.abs(self.FValue).max() - np.abs(self.FValue).min()),
-            (self.endshape[0] / 2, self.endshape[1])).ravel(), (minimum,
+            (self.endshape[0] // 2, self.endshape[1])).ravel(), (minimum,
                                                                 maximum)
 
     def getTransferData(self, redshiftindex):

--- a/RealSpaceInterface/Calc2D/Database.py
+++ b/RealSpaceInterface/Calc2D/Database.py
@@ -14,22 +14,22 @@ class Database:
         self.db_path = os.path.join(directory, db_file)
         if not os.path.exists(self.db_path):
             logging.info("No database found; Creating one at {}.".format(self.db_path))
-            with open(self.db_path, "w") as f:
+            with open(self.db_path, "wb") as f:
                 pickle.dump(dict(), f)
 
         self.db = self.__read_database()
 
     def __read_database(self):
-        with open(self.db_path) as f:
+        with open(self.db_path, "rb") as f:
             return pickle.load(f)
 
     def __write_database(self):
-        with open(self.db_path, "w") as f:
+        with open(self.db_path, "wb") as f:
             pickle.dump(self.db, f)
 
     def __create_file(self, data):
         filename = str(uuid.uuid4())
-        with open(os.path.join(self.directory, filename), "w") as f:
+        with open(os.path.join(self.directory, filename), "wb") as f:
             pickle.dump(data, f)
         return filename
 
@@ -40,7 +40,7 @@ class Database:
         frozen_key = self.__get_frozen_key(key)
         if frozen_key in self.db:
             filename = self.db[frozen_key]
-            with open(os.path.join(self.directory, filename)) as f:
+            with open(os.path.join(self.directory, filename), "rb") as f:
                 return pickle.load(f)
         else:
             raise KeyError("No data for key: {}".format(key))

--- a/RealSpaceInterface/tornadoserver.py
+++ b/RealSpaceInterface/tornadoserver.py
@@ -143,8 +143,8 @@ class DataConnection(tornado.websocket.WebSocketHandler):
         self.write_message(json.dumps({'type': 'extrema', 'extrema': extrema}))
         progress = float(redindex) / len(self.calc.redshift)
 
-        real = {quantity: base64.b64encode(data.astype(np.float32)) for quantity, data in Valuenew.iteritems()}
-        transfer = {quantity: base64.b64encode(data.astype(np.float32)) for quantity, data in TransferData.iteritems()}
+        real = {quantity: base64.b64encode(data.astype(np.float32)).decode() for quantity, data in Valuenew.items()}
+        transfer = {quantity: base64.b64encode(data.astype(np.float32)).decode() for quantity, data in TransferData.items()}
         self.write_message(
             json.dumps({
                 'type': 'data',
@@ -166,9 +166,9 @@ class DataConnection(tornado.websocket.WebSocketHandler):
         extremastring = json.dumps({'type': 'extrema', 'extrema': extrema})
         datastring = json.dumps({
             'type': 'data',
-            'real': base64.b64encode(Value.astype(np.float32)),
+            'real': base64.b64encode(Value.astype(np.float32)).decode(),
             'fourier': [],
-            'transfer': base64.b64encode(TransferData.astype(np.float32)),
+            'transfer': base64.b64encode(TransferData.astype(np.float32)).decode(),
             'k': krange.tolist()
             })
         self.write_message(extremastring)
@@ -212,6 +212,7 @@ class DataConnection(tornado.websocket.WebSocketHandler):
 
             z_of_decoupling = self.calc.z_dec
             frame_of_decoupling = np.argmin(np.abs(z_of_decoupling - self.calc.redshift))
+            frame_of_decoupling = int(frame_of_decoupling)  # this is np.int64 object, which json doesn't like
             if self.calc.redshift[frame_of_decoupling] > z_of_decoupling:
                 frame_of_decoupling -= 1
             messages.append({


### PR DESCRIPTION
The RealSpaceInterface doesn't work out of the box with python3.  This fixes a number of things, including integer division and some type issues related to JSON encoding.  Also makes the database pickle read/writes in binary, which also fixes some type issues.