### PR TITLE
Fix seg fault from ndf15 evolver in #419

### DIFF
--- a/tools/evolver_ndf15.c
+++ b/tools/evolver_ndf15.c
@@ -1306,7 +1306,10 @@ int numjac(
                error_message,error_message);
 
     *nfe+=1;
-    for(i=1;i<=neq;i++) nj_ws->ydel_Fdel[i][j] = nj_ws->ffdel[i];
+    for(i=1;i<=neq;i++){
+      class_test(nj_ws->ffdel[i] != nj_ws->ffdel[i], error_message, "A derivative passed to numjac was NaN.");
+      nj_ws->ydel_Fdel[i][j] = nj_ws->ffdel[i];
+    }
   }
 
 
@@ -1405,6 +1408,7 @@ int numjac(
           Fdiff_absrm = 0.0;
           for(i=1;i<=neq;i++){
             Fdiff_absrm = MAX(Fdiff_absrm,fabs(Fdiff_new));
+            class_test(nj_ws->ffdel[i] != nj_ws->ffdel[i], error_message, "A derivative passed to numjac was NaN."); 
             Fdiff_new = nj_ws->ffdel[i]-fval[i];
             nj_ws->tmp[i] = Fdiff_new/del2;
             if(fabs(Fdiff_new)>=Fdiff_absrm){


### PR DESCRIPTION
This PR fixes a possible segmentation fault arising from `NaN` values being passed to the `numjac` function of the ndf15 numerical solver when asking for the relevant derivatives (i.e. the right-hand-side of the differential equation being solved). I perform a `class_test` whenever the relevant function calculating the derivatives, `*derivs`, is called, so CLASS throws a more informative error, and doesn't break when called in a loop as part of an MCMC chain. 

This fixes #419, where a shooting error is delayed until the background module, but is never actually thrown because the segmentation error occurs first. It also fixes an issue encountered in GAMBIT (https://github.com/GambitBSM), where an unphysical point in the MCMC parameter space causes one or more of the differential equations involved to be ill-defined.