### PR TITLE
more precise explanation of convergence power spectrum

### DIFF
--- a/explanatory.ini
+++ b/explanatory.ini
@@ -39,8 +39,8 @@
 #    with the deflection Cls or the shear/convergence Cls. The relations
 #    between them are trivial:
 #        --> deflection d: Cl^dd = l(l+1) C_l^phiphi
-#        --> convergence kappa and shear gamma: the share the same harmonic
-#            power spectrum: Cl^gamma-gamma = 1/4 * [(l+2)!/(l-2)!] C_l^phi-phi
+#        --> convergence kappa: Cl^kappa-kappa = 1/4 * [l^2 (l+1)^2] C_l^phi-phi
+#        --> shear gamma: Cl^gamma-gamma = 1/4 * [(l+2)!/(l-2)!] C_l^phi-phi
 #    By defaut, the code will try to compute the following cross-correlation
 #    Cls (if available): temperature-polarisation, temperature-CMB lensing,
 #    polarization-CMB lensing, CMB lensing-density, and density-lensing. Other


### PR DESCRIPTION
Slightly modifies the explanatory text on how to obtain the convergence angular power spectrum. The shear angular power spectrum has factors of `(l+2)!/(l-2)!` as previously stated for both convergence and shear, but the convergence should have factor of `l^2 (l+1)^2`.

(Deflection is `d = ð phi`, shear is `ðð phi/2`, but convergence is `ð̅ð phi/2` as necessary to get back to spin 0. The modes are hence `kappa_lm = - 1/2 l (l+1) phi_lm` and the Cls as indicated.)