### PR TITLE
fix make clean for python interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,5 +207,5 @@ classy: libclass.a python/classy.pyx python/cclassy.pxd
 clean: .base
 	rm -rf $(WRKDIR);
 	rm -f libclass.a
-	rm -f $(MDIR)/python/classy.c
+	rm -f $(MDIR)/python/classy.cpp
 	rm -rf $(MDIR)/python/build


### PR DESCRIPTION
Since part of the code switched to C++, it now produces classy.cpp instead of classy.c.
This bug causes `make clean` to not actually remove the productions of the python interface, making modifications to the python interface ineffective (including numpy version switching).