### PR TITLE
Fix buffer size calculation and memory alignment in evolver_ndf15 | Avoid buffer overflow from input

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -29,7 +29,7 @@
 typedef char ErrorMsg[_ERRORMSGSIZE_]; /**< Generic error messages (there is such a field in each structure) */
 
 #define _FILENAMESIZE_ 256 /**< size of the string read in each line of the file (extra characters not taken into account) */
-#define _BASEPATHSIZE_ 1000 /**< allowed size of the base path */
+#define _BASEPATHSIZE_ 1024 /**< allowed size of the base path */
 typedef char FileName[_FILENAMESIZE_+_BASEPATHSIZE_];
 
 #define _SUFFIXNAMESIZE_ 4 /**< maximum size of the short string appended to file names to account for initial conditions, etc. */

--- a/tools/evolver_ndf15.c
+++ b/tools/evolver_ndf15.c
@@ -119,9 +119,9 @@ int evolver_ndf15(
 
   buffer_size=
     15*neqp*sizeof(double)
-    +neqp*sizeof(int)
     +neqp*sizeof(double*)
-    +(7*neq+1)*sizeof(double);
+    +(7*neq+1)*sizeof(double)
+    +neqp*sizeof(int); /* the double and double* (pointer) are 8-bit. For odd neqp, it happens that the int (4-bit) misaligns the memory */
 
   class_alloc(buffer,
           buffer_size,
@@ -143,10 +143,12 @@ int evolver_ndf15(
   tempvec1 =yppinterp+neqp;
   tempvec2 =tempvec1+neqp;
 
-  interpidx=(int*)(tempvec2+neqp);
+  /*interpidx=(int*)(tempvec2+neqp);
 
-  dif      =(double**)(interpidx+neqp);
+  dif      =(double**)(interpidx+neqp);*/
+  dif = (double **)(tempvec2 + neqp);  
   dif[1]   =(double*)(dif+neqp);
+  interpidx=(int *)(dif[1] + 7 * neq + 1); /* put int array last for memory alignment */  
   for(j=2;j<=neq;j++) dif[j] = dif[j-1]+7; /* Set row pointers... */
   dif[0] = NULL;
   /* for (ii=0;ii<(7*neq+1);ii++) dif[1][ii]=0.; */

--- a/tools/hyperspherical.c
+++ b/tools/hyperspherical.c
@@ -1029,7 +1029,7 @@ int hyperspherical_get_xmin(HyperInterpStruct *pHIS,
   int left_index, right_index, index_l, j;
   int nl = pHIS->l_size;
   int nx = pHIS->x_size;
-  int REFINE=10;
+  const int REFINE=10;
   double x[REFINE];
   double Phi[REFINE];
   double *phivec = pHIS->phi;


### PR DESCRIPTION
I was investigating a performance and stability issue in my own CLASS fork [(kabeleh/iDM)](https://github.com/kabeleh/iDM), for which I compiled CLASS with the flags
```
CCFLAG += -fsanitize=undefined 
LDFLAG += -fsanitize=undefined
```
This reported a memory misalignment issue in evolver_ndf15. There is a (4 bit) int array that is in between doubles (8 bit), which causes a misalignment at the boundary. The fix is relatively simple: move the int array to the end.

This was the TL;DR. In more prose:
The ndf15 evolver allocates a single contiguous buffer and carves it into sub-arrays for doubles, an int array (interpidx), a double-pointer array (dif), and a second double region for backward differences.

The original layout placed the int array (neqp × sizeof(int)) between the double arrays and the double-pointer array:

[15×neqp doubles] [neqp ints] [neqp double*] [(7×neq+1) doubles]

When neqp is odd, neqp × 4 bytes leaves the subsequent double* and double regions at a 4-byte boundary, rather than the 8-byte alignment required for these types. This constitutes undefined behaviour in C11 and is flagged at runtime by the -fsanitize=undefined CCFLAG / LDFLAG as misaligned load/store errors during thermodynamics integration.

The solution is to move the int array to the end of the buffer, after all double and double* regions:

[15×neqp doubles] [neqp double*] [(7×neq+1) doubles] [neqp ints]

Since malloc returns memory aligned to at least 8 bytes, and all regions before the int array are multiples of 8 bytes in size, every double and double* access is now aligned. The int array at the tail has no alignment requirement beyond 4 bytes, so placing it last is safe.

The total buffer size is unchanged.
Verified clean under
-fsanitize=undefined,
-fsanitize=address, and
-fsanitize=thread.