### PR TITLE
fix: evolver_ndf15 buffer misalignment (move int region to the end)

### DIFF
--- a/tools/evolver_ndf15.c
+++ b/tools/evolver_ndf15.c
@@ -143,12 +143,11 @@ int evolver_ndf15(
   tempvec1 =yppinterp+neqp;
   tempvec2 =tempvec1+neqp;
 
-  interpidx=(int*)(tempvec2+neqp);
-
-  dif      =(double**)(interpidx+neqp);
+  dif      =(double**)(tempvec2+neqp);
   dif[1]   =(double*)(dif+neqp);
   for(j=2;j<=neq;j++) dif[j] = dif[j-1]+7; /* Set row pointers... */
   dif[0] = NULL;
+  interpidx=(int*)(dif[1]+(7*neq+1));
   /* for (ii=0;ii<(7*neq+1);ii++) dif[1][ii]=0.; */
   for (j=1; j<=neq; j++) {
     for (ii=1;ii<=7;ii++) {


### PR DESCRIPTION
## Summary

Fixes the buffer-partition misalignment in `tools/evolver_ndf15.c` reported in #652.

The shared scratch buffer was partitioned as

```
[15*neqp doubles][neqp ints][neqp double*][(7*neq+1) doubles]
```

The `int` region (`interpidx`) has no alignment requirement, but sitting in the middle forces every later region to inherit its arbitrary length. With `neqp` odd the `double*`/`double` regions end up only 4-byte aligned, so every `dif` pointer load/store and every back-difference-table access is undefined behaviour (UBSan: **44 misaligned-access reports** on `default.ini`, mix of loads and stores on `double*` and `double`).

This PR reorders the partition to

```
[15*neqp doubles][neqp double*][(7*neq+1) doubles][neqp ints]
```

i.e. the alignment-free `int` region moves to the end. Region sizes and the total buffer size are unchanged.

## Verification

- `UBSan (-fsanitize=undefined)` on `default.ini`:
  - before: 44 misaligned-access reports
  - after: **0** (only pre-existing `parser.c` null-pointer-offset reports remain, unrelated to this change)
- Output is numerically unchanged: full run log of `default.ini` is byte-identical to baseline (`age = 13.770598 Gyr`, `z_eq = 3405.751108`, `sigma8 = 0.825009`, `100*theta_s = 1.041798`, `tau_reio = 0.054311`).
- `./class default.ini` exits 0.

## Scope note

The `_BASEPATHSIZE_` change mentioned in the #652 comments (input-path buffer) is intentionally **not** included; happy to open it separately if wanted.

Closes lesgourg/class_public#652 (alignment part).
