### PR TITLE
Update perturbations.c to fix error in equation

### DIFF
--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -8484,7 +8484,7 @@ int perturbations_print_variables(double tau,
       }
 
       if (pba->has_scf == _TRUE_) {
-        delta_scf += alpha*(-3.0*H*(1.0+pvecback[pba->index_bg_p_scf]/pvecback[pba->index_bg_rho_scf]));
+        delta_scf += alpha*(-3.0*a*H*(1.0+pvecback[pba->index_bg_p_scf]/pvecback[pba->index_bg_rho_scf]));
         theta_scf += k*k*alpha;
       }
 


### PR DESCRIPTION
Line 8487 of perturbations.c is wrong, is I commented in a previous closed issue #670 . There is a missing scale factor a(tau) in the transformation of delta_scf.

In particular, the expression for changing from synchronous gauge to Newtonian gauge is the following (Bertschinger, E., & Ma, C. (1995) The Astrophysical Journal, 455, 7.) Eq 27.a

$$ \delta(Con) = \delta(Syn) + \alpha \frac{\dot{\rho}}{\rho} $$

Where H is the cosmological Hubble parameter, $$ \dot f $$ means derivative wrt conformal time. Using the conservation of energy equation and for the scalar field 

$$ \delta_\phi(Con) = \delta_\phi(Syn) - 3aH\alpha \left(1 + \frac{p_{\phi}}{\rho_{\phi}} \right) $$

In the commented line 8487, the scale factor a is missing. I have added it. As you can check, the Hubble parameter H is defined in the same document as 

H = pvecback[pba->index_bg_H];

Where pvecback[pba->index_bg_H] is the cosmological Hubble parameter, defined in background.c Line 579

pvecback[pba->index_bg_H] = sqrt(rho_tot-pba->K/a/a);

Then, the expression needs to be checked. I was finding the wrong behaviour with the perturbations of a scalar field in the synchronous gauge when expressed in conformal one, and was due to this minor typo.

Thank you for your attention